### PR TITLE
Fix configuring admin site title and header in code for Django 1.7

### DIFF
--- a/djangocms_admin_style/templates/admin/inc/branding.html
+++ b/djangocms_admin_style/templates/admin/inc/branding.html
@@ -1,2 +1,2 @@
 {% load i18n %}
-<h1 id="site-name">{% trans 'Django administration' %}</h1>
+<h1 id="site-name">{{ site_header|default:_('Django administration') }}</h1>

--- a/djangocms_admin_style/templates/admin/inc/title.html
+++ b/djangocms_admin_style/templates/admin/inc/title.html
@@ -1,2 +1,2 @@
 {% load i18n %}
-{{ title }} | {% trans 'Django site admin' %}
+{{ title }} | {{ site_title|default:_('Django site admin') }}


### PR DESCRIPTION
Tested with Django 1.5 and doesn't break.

Ref #20.
