### PR TITLE
fix: increase calendarbox width to show sundays

### DIFF
--- a/djangocms_admin_style/sass/components/_forms.scss
+++ b/djangocms_admin_style/sass/components/_forms.scss
@@ -638,7 +638,7 @@ div.calendar {
     }
 }
 div.calendarbox {
-    width: 230px !important;
+    width: 256px !important;
     table {
         margin-bottom: 0 !important;
         td {


### PR DESCRIPTION
This closes issue #422 by increasing the calendar box width. 

Before:
![admin-style_before](https://user-images.githubusercontent.com/40638719/116371908-352abf80-a80c-11eb-8c81-62a5114e6e4d.png)

After:
![admin-style_after](https://user-images.githubusercontent.com/40638719/116371950-3eb42780-a80c-11eb-9cbf-829b71ecbdc4.png)
