### PR TITLE
Remove double click prevention

### DIFF
--- a/djangocms_admin_style/static/djangocms_admin_style/js/base-admin.js
+++ b/djangocms_admin_style/static/djangocms_admin_style/js/base-admin.js
@@ -21,5 +21,4 @@ $(function () {
     initRelatedWidgetWrappers();
     initToolbarDropdown();
     initUpdateNotification();
-    preventDoubleFormSubmissions();
 });


### PR DESCRIPTION
The preventDoubleFormSubmissions() does not work well with django admin actions.

If I for example download a pdf file from django admin action (return a HttpResponse in the action) then the button does not work after the first execution (because of the preventDoubleFormSubmissions()). Only after a reload it will work again, which can be annoying for users.

So I would disable / remove this function. Was there a reason for it? The normal django admin does not do this.