### PR TITLE
feat: Prepare release 3.2.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+3.2.5 (2023-08-22)
+==================
+
+* Add suport for Django 4.2+ dark mode switch buttons
+* Add support for Django 4 view related admin buttons
+* Fix stying issues for Django 4
+* Add support for search field in admin nav (new in Django 4.2)
+
 3.2.4 (2023-04-25)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog
 3.2.5 (2023-08-22)
 ==================
 
-* Add suport for Django 4.2+ dark mode switch buttons
+* Add support for Django 4.2+ dark mode switch buttons
 * Add support for Django 4 view related admin buttons
-* Fix stying issues for Django 4
+* Improve styling compatibility with Django 4.2
 * Add support for search field in admin nav (new in Django 4.2)
 
 3.2.4 (2023-04-25)

--- a/djangocms_admin_style/__init__.py
+++ b/djangocms_admin_style/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Publish the release when ready
 11. Github actions will publish the new package to pypi
 """
-__version__ = '3.2.4'
+__version__ = '3.2.5'


### PR DESCRIPTION
Release 3.2.5 makes the following changes

* Add support for Django 4.2+ dark mode switch buttons
* Add support for Django 4 view related admin buttons
* Improve styling compatibility with Django 4.2
* Add support for search field in admin nav (new in Django 4.2)
