### PR TITLE
/*env*/ entry in .gitignore file allows to name a virtual environment directory flexibly and unambiguously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@
 __pycache__/
 build/
 dist/
-env/
-.venv/
+/*env*/
 
 /~
 /node_modules


### PR DESCRIPTION
/*env*/ entry in .gitignore file is derived from django-cms repository.
This allows developers a better flexibility in naming a virtual environment directory.
So djangocms-admin-style should also apply it in .gitignore specification.

PS: I'm going to work on an issue in django-admin-style and as a contributor, I want the same flexibility in django-admin-style project too :)